### PR TITLE
Add production Dockerfile with standalone output

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.git
+.env*
+*.md
+.vscode
+npm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+
+# --- runner: no node_modules install at all ---
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+RUN addgroup -g 1001 -S nodejs && adduser -S nextjs -u 1001
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+EXPOSE 3000
+ENV PORT=3000
+CMD ["node", "server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nile-quran-nextjs",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@9.15.0",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",


### PR DESCRIPTION
I changed next.config.ts to use output "standalone" to reduce image size because without it the image was around 950MB, and after it reduced to about 300 MB. It only copies the files actually needed at runtime instead of the whole node_modules.

In package.json I pinned packageManager: "pnpm@9.15.0" because without it corepack was pulling the latest pnpm version which needs Node 22, and that was breaking the build since we're on Node 20. I also pinned same version in the dockerifle just for safety.